### PR TITLE
Add magerun_rootdir setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Configurable options, shown here with defaults:
 ```ruby
 set :magerun_roles, :all
 set :magerun_download_url, 'https://raw.github.com/netz98/n98-magerun/master/n98-magerun.phar'
+set :magerun_rootdir, release_path
 ```
 
 ### Installing magerun as part of a deployment

--- a/lib/magerun/tasks/magerun.rake
+++ b/lib/magerun/tasks/magerun.rake
@@ -22,7 +22,7 @@ namespace :magerun do
   task :run, :command do |t, args|
     args.with_defaults(:command => :list)
     on roles fetch(:magerun_roles) do
-      within release_path do
+      within fetch(:magerun_rootdir) do
         execute :'n98-magerun.phar', args[:command], *args.extras
       end
     end
@@ -40,6 +40,7 @@ namespace :load do
 
     set :magerun_roles, :all
     set :magerun_download_url, 'https://raw.github.com/netz98/n98-magerun/master/n98-magerun.phar'
+    set :magerun_rootdir, ->{"#{release_path}"}
 
   end
 end

--- a/lib/magerun/tasks/magerun.rake
+++ b/lib/magerun/tasks/magerun.rake
@@ -40,7 +40,7 @@ namespace :load do
 
     set :magerun_roles, :all
     set :magerun_download_url, 'https://raw.github.com/netz98/n98-magerun/master/n98-magerun.phar'
-    set :magerun_rootdir, ->{"#{release_path}"}
+    set :magerun_rootdir, ->{release_path}
 
   end
 end


### PR DESCRIPTION
The current code assumes that magento is in release_path, this setting will let
magerun find the magento installation. Instead of calling --root-dir it just
calls magerun from the specified directory.
